### PR TITLE
Fix TLS errors

### DIFF
--- a/lib/trans_union/tlo.rb
+++ b/lib/trans_union/tlo.rb
@@ -9,6 +9,9 @@ require 'trans_union/tlo/vehicle_search/response'
 module TransUnion
   module TLO
     extend Constants
+
+    HTTPI.adapter = :excon # force excon as the http adapter
+
     class << self
       attr_accessor :username, :password, :dppa_purpose, :glb_purpose,
                     :permissible_use_code, :version, :wsdl, :convert_nori_string_values

--- a/lib/trans_union/tlo/constants.rb
+++ b/lib/trans_union/tlo/constants.rb
@@ -4,7 +4,7 @@ module TransUnion::TLO
     REQUIRED_CREDENTIALS = [:username, :password, :dppa_purpose, :glb_purpose, :permissible_use_code, :version]
 
     RESOURCE_PATH = Pathname.new(__dir__).join('../../res')
-    CA_CERT = RESOURCE_PATH.join('cacert.pem')
+    # CA_CERT = RESOURCE_PATH.join('cacert.pem')
 
     NAME_SUFFIXES = %w(II III IV V JR SR)
   end

--- a/lib/trans_union/tlo/person_search.rb
+++ b/lib/trans_union/tlo/person_search.rb
@@ -5,8 +5,6 @@ module TransUnion::TLO
 
     client wsdl: TLO_WSDL
     global :convert_request_keys_to, :camelcase
-    global :ssl_version, :TLSv1
-
     global :adapter, :excon
     operations :person_search, :basic_person_search
 
@@ -30,7 +28,8 @@ module TransUnion::TLO
           Password: TransUnion::TLO.password,
           DPPAPurpose: TransUnion::TLO.dppa_purpose,
           GLBPurpose: TransUnion::TLO.glb_purpose,
-          PermissibleUseCode: TransUnion::TLO.permissible_use_code
+          PermissibleUseCode: TransUnion::TLO.permissible_use_code,
+          Version: TransUnion::TLO.version
         }
 
         { 'genericSearchInput' => @base_hash.merge(parse_options(options)) }

--- a/lib/trans_union/tlo/vehicle_search.rb
+++ b/lib/trans_union/tlo/vehicle_search.rb
@@ -4,6 +4,7 @@ module TransUnion::TLO
     include Constants
 
     client wsdl: TLO_WSDL
+    global :adapter, :excon
     global :convert_request_keys_to, :camelcase
 
     operations :vehicle_search

--- a/trans_union.gemspec
+++ b/trans_union.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_dependency 'savon', '>=2.12.0'
+  s.add_dependency 'excon', '>=0.60.0'
 
   s.add_development_dependency 'rspec', '~> 3.4.0'
   s.add_development_dependency 'webmock', '~> 3.0'


### PR DESCRIPTION
They saga may have all come down to some issue with :httpclient as the default adapter for HTTPI lib which is used by Savon.

So 'trans_union' uses 'savon' uses 'httpi' uses 'httpclient' by default, which for some reason was having issues resolving the system path for CA certs and then having issues using TLSv1+

:pray: hopefully this fixes everything